### PR TITLE
Fix #5. Only drain aggregator when it contains data

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -52,6 +52,9 @@ func (a *Aggregator) Put(data []byte, partitionKey string) {
 //
 // If you interested to know more about it. see: aggregation-format.md
 func (a *Aggregator) Drain() (*k.PutRecordsRequestEntry, error) {
+	if a.nbytes == 0 {
+		return nil, nil
+	}
 	data, err := proto.Marshal(&AggregatedRecord{
 		PartitionKeyTable: a.pkeys,
 		Records:           a.buf,

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -56,3 +56,9 @@ func TestAggregation(t *testing.T) {
 		assert(t, found, "record not found after extracting: "+c)
 	}
 }
+
+func TestDrainEmptyAggregator(t *testing.T) {
+	a := new(Aggregator)
+	_, err := a.Drain()
+	assert(t, err == nil, "should not return an error")
+}


### PR DESCRIPTION
Fixes a race condition where multiple goroutines evaluate whether aggregator is ready to drain and then attempt to drain it.