### PR TITLE
Use different defaults for different architectures to avoid integer o…

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,13 +10,10 @@ import (
 // Constants and default configuration take from:
 // github.com/awslabs/amazon-kinesis-producer/.../KinesisProducerConfiguration.java
 const (
-	maxRecordSize        = 1 << 20 // 1MiB
-	maxRequestSize       = 5 << 20 // 5MiB
-	maxRecordsPerRequest = 500
-	maxAggregationSize   = 51200 // 50KB
-	// The KinesisProducerConfiguration set the default to 4294967295L;
-	// it's kinda odd, because the maxAggregationSize is limit to 51200L;
-	maxAggregationCount   = 4294967295
+	maxRecordSize         = 1 << 20 // 1MiB
+	maxRequestSize        = 5 << 20 // 5MiB
+	maxRecordsPerRequest  = 500
+	maxAggregationSize    = 51200 // 50KB
 	defaultMaxConnections = 24
 	defaultFlushInterval  = 5 * time.Second
 )

--- a/maxes.go
+++ b/maxes.go
@@ -1,0 +1,7 @@
+// +build !386
+
+package producer
+
+const (
+	maxAggregationCount = 4294967295
+)

--- a/maxes_386.go
+++ b/maxes_386.go
@@ -1,0 +1,5 @@
+package producer
+
+const (
+	maxAggregationCount = 2147483647
+)


### PR DESCRIPTION
Fixes https://github.com/a8m/kinesis-producer/issues/4 by specifying two different aggregation counts, 1 for 32 bit platforms, one for 64 bit.