### PR TITLE
Critical Bug Fix in high throughput scenarios

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -37,8 +37,10 @@ func (a *Aggregator) Put(data []byte, partitionKey string) {
 	// see: https://github.com/a8m/kinesis-producer/issues/1
 	if len(a.pkeys) == 0 {
 		a.pkeys = append(a.pkeys, partitionKey)
-		a.nbytes += len([]byte(partitionKey))
 	}
+
+	a.nbytes += len([]byte(partitionKey))
+
 	keyIndex := uint64(len(a.pkeys) - 1)
 	a.buf = append(a.buf, &Record{
 		Data:              data,

--- a/aggregator.go
+++ b/aggregator.go
@@ -37,11 +37,12 @@ func (a *Aggregator) Put(data []byte, partitionKey string) {
 	// see: https://github.com/a8m/kinesis-producer/issues/1
 	if len(a.pkeys) == 0 {
 		a.pkeys = append(a.pkeys, partitionKey)
+		a.nbytes += len([]byte(partitionKey))
 	}
 
-	a.nbytes += len([]byte(partitionKey))
-
 	keyIndex := uint64(len(a.pkeys) - 1)
+	// Taking into account the length of the partition key index as part of the protobuff
+	a.nbytes += 8
 	a.buf = append(a.buf, &Record{
 		Data:              data,
 		PartitionKeyIndex: &keyIndex,

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -22,7 +22,7 @@ func TestSizeAndCount(t *testing.T) {
 	for i := 0; i < n; i++ {
 		a.Put(data, pkey)
 	}
-	assert(t, a.Size() == 5*n+5, "size should equal to the data and the partition-key")
+	assert(t, a.Size() == 5*n+5*n, "size should equal to the data and the partition-key")
 	assert(t, a.Count() == n, "count should be equal to the number of Put calls")
 }
 

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -22,7 +22,7 @@ func TestSizeAndCount(t *testing.T) {
 	for i := 0; i < n; i++ {
 		a.Put(data, pkey)
 	}
-	assert(t, a.Size() == 5*n+5*n, "size should equal to the data and the partition-key")
+	assert(t, a.Size() == 5*n+n*8+5, "size should equal to the data and the partition-key")
 	assert(t, a.Count() == n, "count should be equal to the number of Put calls")
 }
 


### PR DESCRIPTION
In high throughput scenarios (>5K records per second), we found that the library would start returning errors from the Amazon API with the following: 

`ValidationException: 4 validation errors detected: Value 'java.nio.HeapByteBuffer[pos=0 lim=1049568 cap=1049568]' at 'records.1.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576; Value 'java.nio.HeapByteBuffer[pos=0 lim=1049568 cap=1049568]' at 'records.2.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576; Value 'java.nio.HeapByteBuffer[pos=0 lim=1049568 cap=1049568]' at 'records.3.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576; Value 'java.nio.HeapByteBuffer[pos=0 lim=1049568 cap=1049568]' at 'records.4.member.data' failed to satisfy constraint: Member must have length less than or equal to 1048576\n\tstatus code: 400, request id: ff9cf821-459a-47cc-aa5e-b87df5522ef2`

When this would happen, the library would get bogged down because it would keep trying to send the same aggregated records (which was too large) and would pretty much deadlock.

The bug is that within the aggregator, you only assume that you have to worry about the size of the Partition Key Index as part of the size of the Protobuff. But its actually part of the protobuff and is part of the overall size of the payload in PutRecords. So if you're over a certain size in  aggregate of messages, the counted data will be over the limit for kinesis. So now we take into account the size of the partition key index in the overall size of the protobuff.