### PR TITLE
Retain user record partition keys

### DIFF
--- a/aggregator.go
+++ b/aggregator.go
@@ -35,7 +35,7 @@ func (a *Aggregator) Put(data []byte, partitionKey string) {
 	a.nbytes += len([]byte(partitionKey))
 	keyIndex := uint64(len(a.pkeys) - 1)
 
-	a.nbytes++ // message index and wire type
+	a.nbytes++ // protobuf message index and wire type
 	a.nbytes += partitionKeyIndexSize
 	a.buf = append(a.buf, &Record{
 		Data:              data,

--- a/aggregator_test.go
+++ b/aggregator_test.go
@@ -22,7 +22,7 @@ func TestSizeAndCount(t *testing.T) {
 	for i := 0; i < n; i++ {
 		a.Put(data, pkey)
 	}
-	assert(t, a.Size() == n+5*n+5*n+8*n, "size should equal to the data and the partition-keys")
+	assert(t, a.Size() == n+5*n+5*n+8*n, "size should equal to size of data, partition-keys, partition key indexes, and protobuf wire type")
 	assert(t, a.Count() == n, "count should be equal to the number of Put calls")
 }
 


### PR DESCRIPTION
With shard mapping and the KPL architecture not implemented, user records are potentially already being aggregated to the wrong shards. However, it would still be nice to retain the original user records' partition keys so that on the consumer side we could expect the documented aggregation format.

I also fixed a bug where we were miscalculating the record size. In edge cases that are easier to reproduce with small user records, I was seeing the following error:

```
com.amazonaws.services.kinesis.model.AmazonKinesisException: 1 validation error detected: 
Value 'java.nio.HeapByteBuffer[pos=0 lim=1048954 cap=1048954]' at 'data' failed to satisfy 
constraint: Member must have length less than or equal to 1048576 (Service: AmazonKinesis; Status 
Code: 400; Error Code: ValidationException; Request ID: f114615a-9256-5a12-a33c-39f52eb5e9c3)
```

Following the discussion on this issue: https://github.com/awslabs/kinesis-aggregation/issues/30 I found that we aren't taking into account the size of the protobuf wire type. See Node.js aggregation library for example: https://github.com/awslabs/kinesis-aggregation/blob/master/node/lib/kpl-agg.js#L60.