### PR TITLE
Support executing start multiple times from same instance of producer

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -129,6 +129,10 @@ func (p *Producer) NotifyFailures() <-chan *FailureRecord {
 // Start the producer
 func (p *Producer) Start() {
 	p.Logger.Info("starting producer", LogValue{"stream", p.StreamName})
+	p.done =       make(chan struct{})
+	p.records =    make(chan *kinesis.PutRecordsRequestEntry, p.Config.BacklogCount)
+	p.semaphore =  make(chan struct{}, p.Config.MaxConnections)
+	p.notify = false
 	go p.loop()
 }
 


### PR DESCRIPTION
Ran into an issue in lambda where every execution after the cold start would fail due to `panic: close of closed channel`.  Therefore leading to a 50% failure rate. 

Root cause was defining the producer as a global variable outside the `Handler` function.  This pull request assumes `Start()` desires idempotency. Please correct me if that is not desired.

```golang
kinesisProducer = producer.New(&producer.Config{
		StreamName:    kinesisStream,
		Client:        kinesisClient,
		BatchCount:    500,
		FlushInterval: 60 * time.Second,
		Logger:        &kplogrus.Logger{Logger: logs}, 
	})

func Handler(ctx context.Context, sqsEvent events.SQSEvent) error {
	kinesisProducer.Start() // <-- always fail after initial cold start

	var wg sync.WaitGroup
	wg.Add(1)

	// concurrently handle failures
	go processPutFailures(&wg)

	processSqsEvent(sqsEvent)

	kinesisProducer.Stop()

	wg.Wait()
        ...
}
```