### PR TITLE
Fix LogValue.String()

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -19,7 +19,7 @@ type LogValue struct {
 }
 
 func (v LogValue) String() string {
-	return fmt.Sprintf(" %s=%s", v.Name, v.Value)
+	return fmt.Sprintf(" %s=%v", v.Name, v.Value)
 }
 
 // StdLogger implements the Logger interface using standard library loggers


### PR DESCRIPTION
Value could be anything than just string. It looks annoying if it's not string.

```
2022/02/18 22:02:53 flushing records reason=interval,  records=%!s(int=1)
```