### PR TITLE
Support config kinesis StreamARN

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type Putter interface {
 // Config is the Producer configuration.
 type Config struct {
 
-	// StreamName is the ARN of the stream.
+	// StreamARN is the ARN of the stream.
 	StreamARN *string
 
 	// StreamName is the Kinesis stream.

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,91 @@
+package producer
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestConfig_ValidStreamArn(t *testing.T) {
+	c := &Config{
+		StreamARN: aws.String("arn:aws:kinesis:us-east-1:012345678901:stream/test-stream-name"),
+	}
+	c.defaults()
+	t.Logf("TestConfig_ValidStreamArn success")
+}
+
+func TestConfig_InvalidStreamArn(t *testing.T) {
+	c := &Config{
+		StreamARN: aws.String("test-stream-name"),
+	}
+	defer func() {
+		r := recover()
+		if r != `kinesis: StreamARN must match pattern "arn:aws.*:kinesis:.*:\d{12}:stream/\S+"`+" current StreamARN: test-stream-name" {
+			t.Errorf("unexpected panic: %v", r)
+		} else {
+			t.Logf("TestConfig_InvalidStreamArn success")
+		}
+	}()
+	c.defaults()
+}
+
+func TestConfig_ValidStreamName(t *testing.T) {
+	c := &Config{
+		StreamName: aws.String("test-stream-name"),
+	}
+	c.defaults()
+	t.Logf("TestConfig_ValidStreamName success")
+}
+
+func TestConfig_InvalidStreamName(t *testing.T) {
+	c := &Config{
+		StreamName: aws.String("test`-stream/name"),
+	}
+	defer func() {
+		r := recover()
+		if r != `kinesis: StreamName must match pattern "[a-zA-Z0-9_.-]+"`+" current StreamName: test`-stream/name" {
+			t.Errorf("unexpected panic: %v", r)
+		} else {
+			t.Logf("TestConfig_InvalidStreamName success")
+		}
+	}()
+	c.defaults()
+}
+
+func TestConfig_BothStreamArnAndName(t *testing.T) {
+	c := &Config{
+		StreamARN:  aws.String("arn:aws:kinesis:us-east-1:012345678901:stream/test-stream-name"),
+		StreamName: aws.String("test-stream-name"),
+	}
+	c.defaults()
+	t.Logf("TestConfig_BothStreamArnAndName success")
+}
+
+func TestConfig_EmptyStreamArnAndName(t *testing.T) {
+	c := &Config{}
+	defer func() {
+		r := recover()
+		if r != `kinesis: either StreamARN or StreamName must be set, recommended use StreamARN` {
+			t.Errorf("unexpected panic: %v", r)
+		} else {
+			t.Logf("TestConfig_EmptyStreamArnAndName success")
+		}
+	}()
+	c.defaults()
+}
+
+func TestConfig_NoMatchStreamArnAndName(t *testing.T) {
+	c := &Config{
+		StreamARN:  aws.String("arn:aws:kinesis:us-east-1:012345678901:stream/test-stream-name"),
+		StreamName: aws.String("test-stream-name-2"),
+	}
+	defer func() {
+		r := recover()
+		if r != `kinesis: StreamName must match the StreamArn current StreamARN: arn:aws:kinesis:us-east-1:012345678901:stream/test-stream-name current StreamName: test-stream-name-2` {
+			t.Errorf("unexpected panic: %v", r)
+		} else {
+			t.Logf("TestConfig_NoMatchStreamArnAndName success")
+		}
+	}()
+	c.defaults()
+}

--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 )
@@ -15,7 +16,7 @@ func ExampleSimple() {
 	cfg, _ := config.LoadDefaultConfig(context.TODO())
 	client := kinesis.NewFromConfig(cfg)
 	pr := New(&Config{
-		StreamName:   "test",
+		StreamName:   aws.String("test"),
 		BacklogCount: 2000,
 		Client:       client,
 		Logger:       logger,

--- a/producer.go
+++ b/producer.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	k "github.com/aws/aws-sdk-go-v2/service/kinesis"
 	ktypes "github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/jpillora/backoff"
@@ -247,7 +246,8 @@ func (p *Producer) flush(records []ktypes.PutRecordsRequestEntry, reason string)
 	for {
 		p.Logger.Info("flushing records", LogValue{"reason", reason}, LogValue{"records", len(records)})
 		out, err := p.Client.PutRecords(context.Background(), &k.PutRecordsInput{
-			StreamName: aws.String(p.StreamName),
+			StreamARN:  p.StreamARN,
+			StreamName: p.StreamName,
 			Records:    records,
 		})
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -154,7 +154,7 @@ var testCases = []testCase{
 
 func TestProducer(t *testing.T) {
 	for _, test := range testCases {
-		test.config.StreamName = test.name
+		test.config.StreamName = aws.String("foo")
 		test.config.MaxConnections = 1
 		test.config.Client = test.putter
 		p := New(test.config)
@@ -181,7 +181,7 @@ func TestProducer(t *testing.T) {
 func TestNotify(t *testing.T) {
 	kError := errors.New("ResourceNotFoundException: Stream foo under account X not found")
 	p := New(&Config{
-		StreamName:          "foo",
+		StreamName:          aws.String("foo"),
 		MaxConnections:      1,
 		BatchCount:          1,
 		AggregateBatchCount: 10,


### PR DESCRIPTION
Compared to setting the stream name, AWS recommends setting the Stream ARN. 

Moreover, in scenarios where data needs to be written to Kinesis streams in other AWS accounts, only the use of the Stream ARN can do this.

ref: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html#API_PutRecords